### PR TITLE
Set client_max_body_size

### DIFF
--- a/files/install/pypi.conf
+++ b/files/install/pypi.conf
@@ -21,6 +21,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    client_max_body_size 20m;
     add_header Pragma "no-cache";
     include uwsgi_params;
     uwsgi_pass 127.0.0.1:3031;


### PR DESCRIPTION
Allow Python packages bigger than 1 MiB